### PR TITLE
fix(Makefile): Correct library path to resolve installation failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,9 @@ install: all
 	mkdir -p $(KMOD_INSTALL_PATH)
 	install -m 644 fake_nvidia_driver.ko $(KMOD_INSTALL_PATH)/
 	echo "fake_nvidia_driver" > /etc/modules-load.d/fake_nvidia_driver.conf
-	depmod -a || true
+	# Explicitly specify the kernel version for depmod. This is essential when building
+	# in a container where the running kernel differs from the target KERNEL_RELEASE.
+	depmod -a $(KVERSION) || true
 
 	# --- Shim Library Installation ---
 	@echo "Installing shim library to $(SHIM_INSTALL_PATH_VERSIONED)..."


### PR DESCRIPTION
The Makefile previously used a hardcoded library installation path (`/usr/lib/x86_64-linux-gnu`), which is specific to Debian-based distributions. This caused the `make install` command to fail on other major Linux families like CentOS, RHEL, and Fedora, which use `/usr/lib64`.

This commit fixes the issue by replacing the static path with a robust, multi-layered detection mechanism. This ensures the correct library directory is used, allowing the project to be installed successfully across different distributions and architectures.

The fix implements the following logic:
1.  **Compiler Query:** It first attempts to determine the system's library directory by querying the C compiler (`$(CC) -print-multi-os-directory`). This is the most reliable method.
2.  **Fallback Check:** If the compiler query is inconclusive, it falls back to checking for the existence of well-known directories.
3.  **User Override:** A `LIBDIR` variable is available to manually specify the path, providing a definitive override for non-standard environments.

-----

Also, the second commit explicitly pass the target kernel version to `depmod` (`depmod -a $(KVERSION)`). This ensures that module dependencies are correctly updated for the kernel that the module was actually built for, improving support for containerized and cross-compilation builds.
